### PR TITLE
Fix footer logo not rendering

### DIFF
--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -1,4 +1,3 @@
-import Image from 'next/image'
 
 const navigation = {
   main: [
@@ -29,8 +28,11 @@ export const Footer = () => {
       </h2>
       <div className="mx-auto max-w-7xl px-6 py-16 sm:py-24 lg:px-8">
         <div className="md:grid md:grid-cols-5 md:gap-8 flex flex-col items-center">
-          <a href="/" className="col-span-2 flex">
-            <Image width={80} height={150} src="/images/logo.svg" alt="Todd Nepola Logo" />
+          <a href="/" className="col-span-2 flex items-center">
+            <div className="bg-white rounded p-1 flex-shrink-0">
+              {/* eslint-disable-next-line @next/next/no-img-element */}
+              <img src="/images/logo.svg" alt="Todd Nepola Logo" width={80} height={100} />
+            </div>
             <div className='grid font-roboto_condensedBold text-primary pl-2 my-0'>
               <span className='text-4xl'>TODD</span>
               <span className='text-6xl '>NEPOLA</span>


### PR DESCRIPTION
### Root cause

Two issues combined to make the footer logo invisible:

1. **Next.js `<Image>` + SVG** — Next.js's image optimizer skips SVG files, and the component was silently failing to render the logo in the footer context (the header logo worked because it had the `priority` prop and sits on a white background).
2. **Color blending** — the right half of `logo.svg` uses `#BABABA` (light gray), which is nearly invisible against the footer's `bg-gray-300` (`#D1D5DB`) background.

### Fix

- Replaced `<Image>` with a standard `<img>` tag — no optimization is applied to SVGs anyway, so there's no downside
- Wrapped the logo in a `bg-white rounded p-1` container so the gray half of the SVG always has contrast regardless of the background color

https://claude.ai/code/session_01Uewny8ZWXEJsMgZG4hSH1U

---
_Generated by [Claude Code](https://claude.ai/code/session_01Uewny8ZWXEJsMgZG4hSH1U)_