### PR TITLE
Fix book section layout on mobile, tablet, and desktop

### DIFF
--- a/src/components/BookSection.js
+++ b/src/components/BookSection.js
@@ -11,12 +11,12 @@ export const BookSection = () => {
                         {/* Remove class [ border-gray-300  dark:border-gray-700 border-dashed border-2 ] to remove dotted border */}
 
                         
-                        <div className="lg:rounded lg:h-[600px] justify-center bg-[url('/images/office_building.png')] bg-cover items-center">
+                        <div className="flex lg:rounded h-[400px] lg:h-[600px] overflow-hidden justify-center bg-[url('/images/office_building.png')] bg-cover items-center">
                           <div className="flex justify-center items-center">
                             <Image
-                              className="object-contain translate-y-20 lg:translate-y-20"
+                              className="object-contain translate-y-10"
                               src="/images/book.png"
-                              alt="Headquarters Image"
+                              alt="Keeping it Real on Commercial Real Estate - Todd Nepola"
                               width="300"
                               height="670"
                             />


### PR DESCRIPTION
Fixes three CSS bugs in `BookSection.js` (issue #1 — swapping `<Image>` — intentionally skipped per request):

**Fix 2 — Missing `flex` on outer container**
`justify-center` and `items-center` are flex/grid utilities; without `flex` on the parent they were no-ops. The book image was never actually centered.

**Fix 3 — No height on mobile + no overflow control**
`lg:h-[600px]` only applied at the large breakpoint. On mobile/tablet the container had no defined height and collapsed unpredictably. Added `h-[400px]` for smaller screens and `overflow-hidden` so the tall book image clips cleanly at the container boundary.

**Fix 4 — Redundant and excessive translate**
`translate-y-20 lg:translate-y-20` — the `lg:` variant was identical to the base and redundant. The 80px shift pushed the image too far down inside the now-bounded container. Reduced to `translate-y-10` (40px) so the book sits visibly within frame at all breakpoints.

https://claude.ai/code/session_01Uewny8ZWXEJsMgZG4hSH1U

---
_Generated by [Claude Code](https://claude.ai/code/session_01Uewny8ZWXEJsMgZG4hSH1U)_