### PR TITLE
Fix book cover image clipped on mobile

### DIFF
--- a/src/components/BookSection.js
+++ b/src/components/BookSection.js
@@ -14,11 +14,11 @@ export const BookSection = () => {
                         <div className="flex lg:rounded h-[400px] lg:h-[600px] overflow-hidden justify-center bg-[url('/images/office_building.png')] bg-cover items-center">
                           <div className="flex justify-center items-center">
                             <Image
-                              className="object-contain translate-y-10"
+                              className="object-contain"
                               src="/images/book.png"
                               alt="Keeping it Real on Commercial Real Estate - Todd Nepola"
-                              width="300"
-                              height="670"
+                              width="280"
+                              height="400"
                             />
                           </div>
                         </div>


### PR DESCRIPTION
The book cover was getting clipped at the bottom on mobile — "TODD T. NEPOLA" and the bottom of the cover were hidden.

**Root cause:** `translate-y-10` (40px downward shift) combined with `overflow-hidden` and `h-[400px]` pushed the tall image past the container boundary.

**Fix:**
- Removed `translate-y-10` so the image sits centered naturally via flex
- Reduced image dimensions from `300×670` to `280×400` so the full cover fits within the mobile container without clipping

https://claude.ai/code/session_01Uewny8ZWXEJsMgZG4hSH1U

---
_Generated by [Claude Code](https://claude.ai/code/session_01Uewny8ZWXEJsMgZG4hSH1U)_