### PR TITLE
Restore book overlay effect with drop shadow

### DIFF
--- a/src/components/BookSection.js
+++ b/src/components/BookSection.js
@@ -11,14 +11,14 @@ export const BookSection = () => {
                         {/* Remove class [ border-gray-300  dark:border-gray-700 border-dashed border-2 ] to remove dotted border */}
 
                         
-                        <div className="flex lg:rounded h-[400px] lg:h-[600px] overflow-hidden justify-center bg-[url('/images/office_building.png')] bg-cover items-center">
+                        <div className="flex lg:rounded h-[400px] lg:h-[600px] justify-center bg-[url('/images/office_building.png')] bg-cover items-center">
                           <div className="flex justify-center items-center">
                             <Image
-                              className="object-contain"
+                              className="object-contain translate-y-16 lg:translate-y-20 drop-shadow-2xl"
                               src="/images/book.png"
                               alt="Keeping it Real on Commercial Real Estate - Todd Nepola"
-                              width="280"
-                              height="400"
+                              width="300"
+                              height="670"
                             />
                           </div>
                         </div>


### PR DESCRIPTION
Restores the original floating/overlay book design where the cover extends past its container, and adds a shadow for depth.

- Removed `overflow-hidden` so the book can protrude below the section
- `translate-y-16` on mobile, `translate-y-20` on desktop for the overlay effect
- Restored original `300×670` image dimensions
- Added `drop-shadow-2xl` so the book has a prominent shadow against the background

https://claude.ai/code/session_01Uewny8ZWXEJsMgZG4hSH1U

---
_Generated by [Claude Code](https://claude.ai/code/session_01Uewny8ZWXEJsMgZG4hSH1U)_