### PR TITLE
Fix footer logo white background and iOS overscroll

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -2,6 +2,10 @@
 @tailwind components;
 @tailwind utilities;
 
+html, body {
+  background-color: #d1d5db;
+}
+
 .primaryCTA {
   border-image-source: linear-gradient(to top right, #000000, #0037ff);
   border-image-slice: 1;

--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -29,7 +29,7 @@ export const Footer = () => {
       <div className="mx-auto max-w-7xl px-6 py-16 sm:py-24 lg:px-8">
         <div className="md:grid md:grid-cols-5 md:gap-8 flex flex-col items-center">
           <a href="/" className="col-span-2 flex items-center">
-            <div className="bg-white rounded p-1 flex-shrink-0">
+            <div className="flex-shrink-0">
               {/* eslint-disable-next-line @next/next/no-img-element */}
               <img src="/images/logo.svg" alt="Todd Nepola Logo" width={80} height={100} />
             </div>


### PR DESCRIPTION
## Summary
- **Footer logo**: Removed `bg-white rounded p-1` wrapper so the logo now has a transparent background
- **iOS overscroll**: Set `html, body` background to `#d1d5db` (Tailwind gray-300) to match the footer. On iOS Safari, rubber-band scrolling past the footer was showing the browser's default white/gray background — now it seamlessly matches.

https://claude.ai/code/session_01Uewny8ZWXEJsMgZG4hSH1U

---
_Generated by [Claude Code](https://claude.ai/code/session_01Uewny8ZWXEJsMgZG4hSH1U)_