### PR TITLE
Fix iOS overscroll without gray body bleed

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -2,7 +2,11 @@
 @tailwind components;
 @tailwind utilities;
 
-html, body {
+footer::after {
+  content: '';
+  display: block;
+  height: 50vh;
+  margin-bottom: -50vh;
   background-color: #d1d5db;
 }
 


### PR DESCRIPTION
## Problem
PR #9 set `html, body` background to gray-300 to fix iOS overscroll, but that gray bled through everywhere — between sections, at the top of the page, etc.

## Fix
- Reverted body background to default (white)
- Added a `footer::after` pseudo-element: 50vh tall with negative bottom margin so it's hidden during normal scrolling, but extends the footer's gray color into the overscroll zone on iOS Safari/Chrome rubber-band bounce

https://claude.ai/code/session_01Uewny8ZWXEJsMgZG4hSH1U

---
_Generated by [Claude Code](https://claude.ai/code/session_01Uewny8ZWXEJsMgZG4hSH1U)_