### PR TITLE
Redesign CoStar Power Broker badge into Industry Recognition section

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -41,10 +41,6 @@ export default function Home() {
           </div>
         </div>
 
-        <div className="flex flex-col items-center justify-center py-16 bg-white">
-          <Image src="/images/costar-power-broker-2025.png" alt="CoStar Power Broker 2025 Top Broker Winner" width={250} height={250} />
-        </div>
-
       <div className="flex bg-[url('/images/investment2_1.jpg')] bg-cover bg-no-repeat bg-center flex-col items-center justify-center lg:py-10">
         <div className="container mx-auto grid sm:grid-cols-1 md:grid-cols-2 lg:grid-cols-2 xl:grid-cols-2 lg:pt-6 lg:gap-8">
                 <div className="rounded bg-black content-center bg-opacity-60 bg-cover bg-center justify-center grid" >
@@ -84,6 +80,27 @@ export default function Home() {
         </div>
         </div>
 
+      <div className="flex flex-col items-center justify-center py-16 bg-primary">
+        <h2 className="text-center uppercase font-roboto_condensedBold text-white my-2 mb-12 text-5xl">
+          Industry Recognition
+        </h2>
+        <div className="container mx-auto grid grid-cols-1 lg:grid-cols-2 gap-8 items-center px-4">
+          <div className="flex justify-center">
+            <Image src="/images/costar-power-broker-2025.png" alt="CoStar Power Broker 2025 Top Broker Winner" width={280} height={280} />
+          </div>
+          <div className="flex flex-col gap-4">
+            <h3 className="text-white font-roboto_condensedBold text-3xl">
+              CoStar Power Broker Award
+            </h3>
+            <p className="text-gray-300 text-xl">
+              Todd Nepola has been recognized as a multiple-time winner of CoStar&apos;s prestigious Power Broker Award, most recently at CCM in 2025. This annual honor is awarded to the top commercial real estate brokers and firms who closed the highest transaction volumes in their markets.
+            </p>
+            <p className="text-gray-300 text-xl">
+              The recognition is a testament to Current Capital&apos;s consistent performance and Todd&apos;s dedication to delivering exceptional results in commercial real estate across South Florida.
+            </p>
+          </div>
+        </div>
+      </div>
 
         <section>
           <div className="flex flex-col items-center justify-center my-16">


### PR DESCRIPTION
## Summary
- Moved the CoStar Power Broker badge from a standalone image between the Book and Current Capital sections to a dedicated "Industry Recognition" section placed after Current Capital
- Added a section heading, subheading, and descriptive copy explaining the Power Broker award
- Two-column responsive layout: badge left + text right on desktop, stacked vertically on mobile
- Styled with the site's primary dark blue background to match surrounding sections

## Test plan
- [ ] Verify the badge section appears after Current Capital and before About Todd Nepola
- [ ] Check desktop layout: badge on left, text on right
- [ ] Check mobile layout: badge stacks above text
- [ ] Confirm the old standalone badge div is removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)